### PR TITLE
エネミーとプレイヤー弾の当たり判定追加、雑魚エネミーが出すMP4弾の数を変更

### DIFF
--- a/UnityProject/Assets/Scripts/Enemy/EnemyBulletPattern.cs
+++ b/UnityProject/Assets/Scripts/Enemy/EnemyBulletPattern.cs
@@ -36,3 +36,22 @@ public class EnemyBulletPatternFirst : EnemyBulletPattern
         }
     }
 }
+
+public class EnemyBulletPatternNormal : EnemyBulletPattern
+{
+
+    public override void Update(EnemyController enemy)
+    {
+        enemy.BulletTime += Time.deltaTime;
+
+        if (enemy.BulletTime >= enemy.BulletInterval)
+        {
+            enemy.BulletTime = 0;
+            // 弾の発射
+            Bullet bullet = Object.Instantiate(enemy.Bullet);
+            bullet.Shoot(new Vector2(0.75f, -0.75f), enemy.gameObject);
+            bullet = Object.Instantiate(enemy.Bullet);
+            bullet.Shoot(new Vector2(-0.75f, -0.75f), enemy.gameObject);
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/Enemy/EnemyController.cs
+++ b/UnityProject/Assets/Scripts/Enemy/EnemyController.cs
@@ -66,6 +66,12 @@ public class EnemyController : MonoBehaviour {
             enemyPattern.ChangePattern(this);
             player.AddDignity(-0.05f);
         }
+        // 衝突：プレイヤー弾
+        if(layerName == "PlayerBullet")
+        {
+            // 破壊
+            enemyPattern.Destroy(this);
+        }
     }
 
     public void ChangeSpriteDiffusion()

--- a/UnityProject/Assets/Scripts/Enemy/EnemyPattern.cs
+++ b/UnityProject/Assets/Scripts/Enemy/EnemyPattern.cs
@@ -9,6 +9,7 @@ public class EnemyPattern
     public virtual void Init(EnemyController enemy) { }             // 初期化
     public virtual void Update(EnemyController enemy) { }           // 更新
     public virtual void ChangePattern(EnemyController enemy) { }    // 状態遷移
+    public virtual void Destroy(EnemyController enemy) { }          // 破壊
 }
 
 // エネミーが生成位置から反対側まで移動する
@@ -36,7 +37,7 @@ public class EnemyPatternStart : EnemyPattern
     public override void ChangePattern(EnemyController enemy)
     {
         enemy.ChangeEnemyPattern(new EnemyPatternDiffusion());
-        enemy.ChangeEnemyBulletPattern(new EnemyBulletPatternFirst());
+        enemy.ChangeEnemyBulletPattern(new EnemyBulletPatternNormal());
         enemy.EnemyPattern.Init(enemy);
         enemy.ChangeSpriteDiffusion();
     }
@@ -64,6 +65,11 @@ public class EnemyPatternDiffusion : EnemyPattern
     {
         //enemy.ChangeEnemyPattern(new EnemyPatternNormal());
         enemy.EnemyPattern.Init(enemy);
+    }
+
+    public override void Destroy(EnemyController enemy)
+    {
+        Object.Destroy(enemy.gameObject);
     }
 }
 


### PR DESCRIPTION
## 概要
・雑魚エネミーがMP4拡散状態のときにプレイヤー弾がヒットすると消滅するように処理を追加。
・雑魚エネミーが出すMP4弾の数を3から2に変更。